### PR TITLE
Add reusable workflows for compiling and tagging

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,32 @@
+name: Compilation and UTests
+
+on:
+  workflow_call:
+    inputs:
+      name: 
+        required: true
+        type: string
+
+jobs:
+  compilation:
+    permissions:
+      checks: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build ${{ inputs.name }}
+        uses: apes-suite/build-action@v1.1.1
+        with:
+          waf-args: "configure build debug"
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2.19.0
+        with:
+          files: |
+            build/**/waf-utest.xml
+          check_name: "Waf Unit Tests"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,57 @@
+name: Bump version
+# Increment version on merge to master from pull request
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+concurrency:
+  group: tagging
+  
+jobs:
+  autotag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      new-tag: ${{ startsWith(steps.tagbump.outputs.new-tag, 'v') && steps.tagbump.outputs.new-tag || format('v{0}', steps.tagbump.outputs.new-tag) }}
+      otag: ${{ steps.tagbump.outputs.tag }}
+    strategy:
+      matrix:
+        node-version:
+          - 12
+    steps:
+      - name: Bump version and push tag
+        id: tagbump
+        uses: phish108/autotag-action@v1.1.64
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          with-v: true
+
+  movetags:
+    needs: autotag
+    if: ${{ needs.autotag.outputs.new-tag != needs.autotag.outputs.otag }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+      - name: Get semvers and update MAJOR and MINOR tags
+        run: |
+          echo "old tag: ${{ needs.autotag.outputs.otag }}"
+          FULL=${{ needs.autotag.outputs.new-tag }}
+          MINOR=${FULL%.*}
+          MAJOR=${MINOR%%.*}
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -fa "${MAJOR}" -m 'Major release'
+          git push origin "${MAJOR}" --force
+          git tag -fa "${MINOR}" -m 'Minor release'
+          git push origin "${MINOR}" --force

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # reus
 Reusable Github workflows for the APES repositories
+
+* **compile.yml**: compile `build debug` with the build-action for an APES tool.
+  Takes a `name` input parameter to label the build step accordingly.
+  The waf unit tests are being run and their report is published accordingly.
+  This should only be run in pull request.
+
+* **tag.yml**: automatically tag the repository with a new version with the
+  [autotag-action](https://github.com/phish108/autotag-action), it should be used
+  upon closing a pull request. Versions are following the semver format of
+  `v#major.#minor.#patch`. To indicate which level should be increased, the commits
+  have to contain on of those tags. The default is `#patch`.


### PR DESCRIPTION
Add callable workflows to reduce gh code duplication
across apes repositories.
