### PR TITLE
Use always() && for artifacts in compile.yml

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -56,7 +56,7 @@ jobs:
         uses: apes-suite/pysys-action@v1.0.2
 
       - name: Upload PySys archive artifacts for any test failures
-        if: failure() && inputs.systest == true && steps.pysys.outputs.artifact_TestOutputArchiveDir
+        if: always() && inputs.systest == true && steps.pysys.outputs.artifact_TestOutputArchiveDir
         uses: actions/upload-artifact@v4.6.2
         with:
           name: pysys_output


### PR DESCRIPTION
Use `always() &&` instead of `failure() &&` in the condition for the artifact generation. The `TestOutputArchiveDir` is only filled by pysys if there is a failure already.