### PR TITLE
Use the testrundir output for artifact upload

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -60,17 +60,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: pysys_output
-          path: ${{ steps.pysys.outputs.artifact_TestOutputArchiveDir }}
-          
-      - name: Show testrundir
-        if: always()
-        run: |
-          pwd
-          echo ${{ steps.pysys.outputs.testrundir }}
-          ls -la ${{ steps.pysys.outputs.testrundir }}
-          ls -la ${{ steps.pysys.outputs.testrundir }}/__pysys_output_archives
-          ls -la ${{ steps.pysys.outputs.artifact_TestOutputArchiveDir }}
-        shell: bash
+          path: ${{ steps.pysys.outputs.testrundir }}/__pysys_output_archives
 
       - name: Publish SysTest Results
         if: always() && inputs.systest == true


### PR DESCRIPTION
This is a #minor version bump which should allow the artifact uploader to find the pysys output. So far it had the wrong path, due to the pysys action running in a docker environment.